### PR TITLE
use compose() for combining circuits instead of +

### DIFF
--- a/quantumblur/quantumblur.py
+++ b/quantumblur/quantumblur.py
@@ -763,9 +763,9 @@ def blur_height(height, xi, axis='x', circuit=None, log=False):
             
     # add to initial circuit
     if circuit:
-        circuit = circuit + qc_rot
+        circuit = circuit.compose(qc_rot)
     else:
-        circuit = height2circuit(height,log=log) + qc_rot
+        circuit = height2circuit(height,log=log).compose(qc_rot)
     circuit.name = '('+str(Lx)+','+str(Ly)+')'
         
     return circuit


### PR DESCRIPTION
In Qiskit 0.43.0, the `+` operator is no longer supported for combining circuits.

For example, this code from `quantumblur.py`:
`circuit + qc_rot`,
will produce the following error:
`unsupported operand type(s) for +: 'QuantumCircuit' and 'QuantumCircuit'`.

I've replaced the two instances in which `+` is used to combine circuits with the new recommended practice: `QuantumCircuit.compose()`.