### PR TITLE
Replace MicroQiskit with MicroMoth

### DIFF
--- a/QuickStart.ipynb
+++ b/QuickStart.ipynb
@@ -946,9 +946,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Another important point to note is that the circuits produced by `quantum_blur` do not include measurement gates. This does not pose any problem if you are using a backend that does not require measurement gates (such as `Statevector` or `DensityMatrix` simulation with Qiskit or by using `get='probabilities_dict'` with MicroQiskit).\n",
+    "Another important point to note is that the circuits produced by `quantum_blur` do not include measurement gates. This does not pose any problem if you are using a backend that does not require measurement gates (such as `Statevector` or `DensityMatrix` simulation).\n",
     "\n",
-    "To run on a real quantum device or emulation thereof (using a qasm simulator) measurement operations will need to be added. When using Qiskit, this can be done with a single command."
+    "To run on a real quantum device or emulation thereof (using a qasm simulator) measurement operations will need to be added. This can be done with a single command."
    ]
   },
   {
@@ -964,16 +964,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For MicroQiskit you could instead create an equal sized circuit that also has a classical register, fill it with measurements and add it on.\n",
-    "\n",
-    "```\n",
-    "meas = QuantumCircuit(qc.num_qubits,qc.num_qubits)\n",
-    "for j in range(qc.num_qubits):\n",
-    "    qc.measure(j,j)\n",
-    "qc = qc + meas\n",
-    "```\n",
-    "\n",
-    "Either way, the next step is to run it. Here's how to do that using the qasm simulator of Qiskit Aer."
+    "The next step is to run it. Here's how to do that using the qasm simulator of Qiskit Aer."
    ]
   },
   {

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ In this respository is a Python version of the source code, but there is also a 
 ## Requirements
 
 Either of the following:
-* Any Python from 2.7 and beyond, with only the standard library and [MicroQiskit](https://github.com/qiskit-community/MicroQiskit);
 * Python 3.7 and beyond with Qiskit, NumPy, SciPy and PIL.
+* Any Python from 2.7 and beyond, with only the standard library and [MicroMoth](https://github.com/qiskit-community/MicroQiskit) (A minimal quantum SDK, previously known as [MicroQiskit](https://github.com/qiskit-community/MicroQiskit));
 
-The latter is recommended, but the former is more flexible to running everything in strange places.
+The former is recommended, but the latter is more flexible to running everything in strange places.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ In this respository is a Python version of the source code, but there is also a 
 ## Requirements
 
 Either of the following:
-* Python 3.7 and beyond with Qiskit, NumPy, SciPy and PIL.
+* Python 3.9 and beyond with Qiskit, NumPy, SciPy and PIL.
 * Any Python from 2.7 and beyond, with only the standard library and [MicroMoth](https://github.com/moth-quantum/MicroMoth) (A minimal quantum SDK, previously known as [MicroQiskit](https://github.com/qiskit-community/MicroQiskit));
 
 The former is recommended, but the latter is more flexible to running everything in strange places.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ In this respository is a Python version of the source code, but there is also a 
 
 Either of the following:
 * Python 3.7 and beyond with Qiskit, NumPy, SciPy and PIL.
-* Any Python from 2.7 and beyond, with only the standard library and [MicroMoth](https://github.com/qiskit-community/MicroQiskit) (A minimal quantum SDK, previously known as [MicroQiskit](https://github.com/qiskit-community/MicroQiskit));
+* Any Python from 2.7 and beyond, with only the standard library and [MicroMoth](https://github.com/moth-quantum/MicroMoth) (A minimal quantum SDK, previously known as [MicroQiskit](https://github.com/qiskit-community/MicroQiskit));
 
 The former is recommended, but the latter is more flexible to running everything in strange places.
 

--- a/quantumblur/quantumblur.py
+++ b/quantumblur/quantumblur.py
@@ -19,7 +19,7 @@ The imports that follow are highly non-standard and require some explanation.
 This file is designed to run in both a modern, fully functioning Python
 environment, with Python 3.x and the ability to use external libraries.
 It is also designed to function using only the standard library (in
-addition to MicroQiskit) in any Python from 2.7 onwards.
+addition to MicroMoth) in any Python from 2.7 onwards.
 
 The deciding factor is whether Qiskit is available to be imported. If so,
 the following external libraries are required dependencies:
@@ -29,7 +29,7 @@ numpy
 scipy
 PIL
 
-Otherwise, MicroQiskit will be used in place of Qiskit, and alternative
+Otherwise, MicroMoth will be used in place of Qiskit, and alternative
 techniques using only the standard library will be used in place of the
 other dependencies.
 
@@ -37,22 +37,22 @@ More information on Qiskit can be found at
 
 https://qiskit.org
 
-and information on MicroQiskit can be found at
+and information on MicroMoth can be found at
 
-https://github.com/qiskit-community/MicroQiskit
+https://github.com/moth-quantum/MicroMoth
 """
 
 import math
 import random
 
 # determine whether qiskit can be used, or whether to default to
-# MicroQiskit and the standard library
+# MicrMoth and the standard library
 try:
     from qiskit import QuantumCircuit, quantum_info
     simple_python = False
 except:
-    print('Unable to import Qiskit, so MicroQiskit will be used instead')
-    from microqiskit import QuantumCircuit, simulate
+    print('Unable to import Qiskit, so MicroMoth will be used instead')
+    from micromoth import QuantumCircuit, simulate
     simple_python = True
 
     
@@ -346,7 +346,7 @@ def height2circuit(height, log=False, eps=1e-2):
     # define and initialize quantum circuit            
     qc = QuantumCircuit(n)
     if simple_python:
-        # microqiskit style
+        # micromoth style
         qc.initialize(state)
     else:
         qc.initialize(state,range(n))


### PR DESCRIPTION
[MicroQiskit](https://github.com/qiskit-community/MicroQiskit) has been archived. Ongoing development and support will be done at the active fork known as [MicroMoth](https://github.com/moth-quantum/MicroMoth). The import commands for when Qiskit is not available have been updated accordingly.

Qiskit remains the default quantum SDK to be used. The alternative is only for use with Python 2 or microcontrollers.